### PR TITLE
Subgroups training of wn18rr dataset with rescal model

### DIFF
--- a/examples/wnrr-rescal.yaml
+++ b/examples/wnrr-rescal.yaml
@@ -1,5 +1,4 @@
 job.type: train
-dataset.name: toy
 
 KvsAll:
   label_smoothing: 0.3

--- a/examples/wnrr-rescal.yaml
+++ b/examples/wnrr-rescal.yaml
@@ -1,0 +1,68 @@
+job.type: train
+dataset.name: toy
+
+KvsAll:
+  label_smoothing: 0.3
+dataset:
+  name: wnrr
+eval:
+  batch_size: 256
+  metrics_per:
+    relation_type: true
+  trace_level: example
+import:
+- reciprocal_relations_model
+- rescal
+lookup_embedder:
+  dim: 128
+  initialize: uniform_
+  initialize_args:
+    normal_:
+      mean: 0.0
+      std: 0.040050258996206144
+    uniform_:
+      a: -0.4063789847256075
+    xavier_normal_:
+      gain: 1.0
+    xavier_uniform_:
+      gain: 1.0
+  regularize_args:
+    p: 3
+model: reciprocal_relations_model
+negative_sampling:
+  implementation: batch
+  num_samples:
+    p: -1
+reciprocal_relations_model:
+  base_model:
+    relation_embedder:
+      dim: 16384
+    type: rescal
+rescal:
+  entity_embedder:
+    dropout: -0.29821809173392233
+    regularize_weight: 2.7316949258356523e-14
+  relation_embedder:
+    dropout: 0.23784801073601625
+    regularize_weight: 5.1397914949342275e-15
+train:
+  auto_correct: true
+  batch_size: 128
+  loss_arg: 1.0
+  lr_scheduler: ReduceLROnPlateau
+  lr_scheduler_args:
+    factor: 0.95
+    mode: max
+    patience: 8
+    threshold: 0.0001
+  max_epochs: 400
+  optimizer: Adam
+  optimizer_args:
+    lr: 0.0008535391032574453
+valid:
+  early_stopping:
+    min_threshold:
+      epochs: 50
+      metric_value: 0.05
+    patience: 10
+

--- a/kge/util/group.py
+++ b/kge/util/group.py
@@ -1,0 +1,6 @@
+from kge.model import KgeModel
+from kge.util.io import load_checkpoint
+
+checkpoint = load_checkpoint('local/experiments/20241021-193745-wnrr-rescal/checkpoint_best.pt')
+model = KgeModel.create_from(checkpoint)
+print(model)

--- a/kge/util/group.py
+++ b/kge/util/group.py
@@ -9,12 +9,21 @@ model = KgeModel.create_from(checkpoint)
 test_triples  = model.dataset.split("test")
 
 relation_groups = defaultdict(list)
+subject_groups = defaultdict(list)
+predicate_groups = defaultdict(list)
+
 
 for triple in test_triples:
+    subject = triple[0].item()
     relation = triple[1].item()
-    relation_groups[relation].append(triple)
+    predicate = triple[2].item()
 
-def evaluate_group(model, triples):
+    subject_groups[subject].append(triple)
+    relation_groups[relation].append(triple)
+    predicate_groups[predicate].append(triple)
+
+
+def evaluate(model, triples):
     # Convert the list of triples to a tensor
     triples_tensor = torch.stack(triples).to(model.config.get("job.device"))
 
@@ -32,6 +41,9 @@ def evaluate_group(model, triples):
     # Return the evaluation results (including MRR, Hits@k)
     return eval_job.result
 
-for relation, triples in relation_groups.items():
-    print(f"Evaluating relation: {relation}")
-    results = evaluate_group(model, relation_groups[relation])
+def eval_subgroup(sub):
+    for key, triples in sub.items():
+        print(f"Evaluating relation: {key}")
+        results = evaluate(model, sub[key])
+
+eval_subgroup(relation_groups)

--- a/kge/util/group.py
+++ b/kge/util/group.py
@@ -17,12 +17,6 @@ for triple in test_triples:
 def evaluate_group(model, triples):
     # Convert the list of triples to a tensor
     triples_tensor = torch.stack(triples).to(model.config.get("job.device"))
-    # Evaluate using the model's scoring function
-    # results = model.score_sp_po(triples_tensor[:, 0], triples_tensor[:, 1], triples_tensor[:, 2])
-    # return results
-
-    
-
 
     eval_job = EvaluationJob.create(model.config, dataset=model.dataset, model=model)
     # Prepare and run the evaluation
@@ -33,7 +27,7 @@ def evaluate_group(model, triples):
         collate_fn=eval_job._collate,
     )
     eval_job.loader = custom_loader
-    eval_job.result = eval_job._run()  # Run the evaluation on this subgroup
+    eval_job.result = eval_job._run()
     
     # Return the evaluation results (including MRR, Hits@k)
     return eval_job.result
@@ -41,4 +35,3 @@ def evaluate_group(model, triples):
 for relation, triples in relation_groups.items():
     print(f"Evaluating relation: {relation}")
     results = evaluate_group(model, relation_groups[relation])
-    print(f"Results for relation {relation}: {results}")

--- a/kge/util/group.py
+++ b/kge/util/group.py
@@ -1,6 +1,44 @@
+import torch
+from kge.job.eval import EvaluationJob
 from kge.model import KgeModel
 from kge.util.io import load_checkpoint
+from collections import defaultdict
 
 checkpoint = load_checkpoint('local/experiments/20241021-193745-wnrr-rescal/checkpoint_best.pt')
 model = KgeModel.create_from(checkpoint)
-print(model)
+test_triples  = model.dataset.split("test")
+
+relation_groups = defaultdict(list)
+
+for triple in test_triples:
+    relation = triple[1].item()
+    relation_groups[relation].append(triple)
+
+def evaluate_group(model, triples):
+    # Convert the list of triples to a tensor
+    triples_tensor = torch.stack(triples).to(model.config.get("job.device"))
+    # Evaluate using the model's scoring function
+    # results = model.score_sp_po(triples_tensor[:, 0], triples_tensor[:, 1], triples_tensor[:, 2])
+    # return results
+
+    
+
+
+    eval_job = EvaluationJob.create(model.config, dataset=model.dataset, model=model)
+    # Prepare and run the evaluation
+    eval_job._prepare()
+    # Override the loader with the custom DataLoader
+    custom_loader = torch.utils.data.DataLoader(
+        triples_tensor, batch_size=model.config.get("eval.batch_size"), shuffle=False,
+        collate_fn=eval_job._collate,
+    )
+    eval_job.loader = custom_loader
+    eval_job.result = eval_job._run()  # Run the evaluation on this subgroup
+    
+    # Return the evaluation results (including MRR, Hits@k)
+    return eval_job.result
+
+for relation, triples in relation_groups.items():
+    print(f"Evaluating relation: {relation}")
+    results = evaluate_group(model, relation_groups[relation])
+    print(f"Results for relation {relation}: {results}")

--- a/kge/util/subgroup.py
+++ b/kge/util/subgroup.py
@@ -4,47 +4,49 @@ from kge.model import KgeModel
 from kge.util.io import load_checkpoint
 from collections import defaultdict
 
+# Load model and data
 checkpoint = load_checkpoint('local/experiments/20241021-193745-wnrr-rescal/checkpoint_best.pt')
 model = KgeModel.create_from(checkpoint)
-test_triples  = model.dataset.split("test")
+test_triples = model.dataset.split("test")
 
-relation_groups = defaultdict(list)
-subject_groups = defaultdict(list)
-predicate_groups = defaultdict(list)
+def group_triples(triples, group_type="relation"):
+    groups = defaultdict(list)
+    for triple in triples:
+        if group_type == "subject":
+            key = triple[0].item()
+        elif group_type == "relation":
+            key = triple[1].item()
+        elif group_type == "object":
+            key = triple[2].item()
+        else:
+            raise ValueError("Invalid group_type. Choose from 'subject', 'relation', or 'object'.")
+        groups[key].append(triple)
+    return groups
 
-
-for triple in test_triples:
-    subject = triple[0].item()
-    relation = triple[1].item()
-    predicate = triple[2].item()
-
-    subject_groups[subject].append(triple)
-    relation_groups[relation].append(triple)
-    predicate_groups[predicate].append(triple)
-
-
+# Evaluate function to assess performance on a batch of triples
 def evaluate(model, triples):
-    # Convert the list of triples to a tensor
+    # Convert list of triples to 2D tensor
     triples_tensor = torch.stack(triples).to(model.config.get("job.device"))
 
     eval_job = EvaluationJob.create(model.config, dataset=model.dataset, model=model)
-    # Prepare and run the evaluation
     eval_job._prepare()
-    # Override the loader with the custom DataLoader
+    
+    # Override DataLoader with custom triples tensor
     custom_loader = torch.utils.data.DataLoader(
         triples_tensor, batch_size=model.config.get("eval.batch_size"), shuffle=False,
         collate_fn=eval_job._collate,
     )
     eval_job.loader = custom_loader
     eval_job.result = eval_job._run()
-    
-    # Return the evaluation results (including MRR, Hits@k)
     return eval_job.result
 
-def eval_subgroup(sub):
-    for key, triples in sub.items():
-        print(f"Evaluating relation: {key}")
-        results = evaluate(model, sub[key])
-        print(results)
+# Main function to evaluate subgroups based on group type
+def eval_subgroups(model, triples, group_type):
+    groups = group_triples(triples, group_type)
+    for key, triples in groups.items():
+        print(f"Evaluating {group_type} subgroup with key {key}")
+        results = evaluate(model, triples)
+        print(f"Results for {group_type} {key}: {results}")
 
-eval_subgroup(relation_groups)
+# Execute subgroup evaluation by desired grouping type
+eval_subgroups(model, test_triples, group_type="relation")

--- a/kge/util/subgroup.py
+++ b/kge/util/subgroup.py
@@ -45,5 +45,6 @@ def eval_subgroup(sub):
     for key, triples in sub.items():
         print(f"Evaluating relation: {key}")
         results = evaluate(model, sub[key])
+        print(results)
 
 eval_subgroup(relation_groups)

--- a/kge/util/subgroup.py
+++ b/kge/util/subgroup.py
@@ -4,49 +4,57 @@ from kge.model import KgeModel
 from kge.util.io import load_checkpoint
 from collections import defaultdict
 
-# Load model and data
-checkpoint = load_checkpoint('local/experiments/20241021-193745-wnrr-rescal/checkpoint_best.pt')
-model = KgeModel.create_from(checkpoint)
-test_triples = model.dataset.split("test")
-
-def group_triples(triples, group_type="relation"):
-    groups = defaultdict(list)
-    for triple in triples:
-        if group_type == "subject":
-            key = triple[0].item()
-        elif group_type == "relation":
-            key = triple[1].item()
-        elif group_type == "object":
-            key = triple[2].item()
-        else:
-            raise ValueError("Invalid group_type. Choose from 'subject', 'relation', or 'object'.")
-        groups[key].append(triple)
-    return groups
-
-# Evaluate function to assess performance on a batch of triples
-def evaluate(model, triples):
-    # Convert list of triples to 2D tensor
-    triples_tensor = torch.stack(triples).to(model.config.get("job.device"))
-
-    eval_job = EvaluationJob.create(model.config, dataset=model.dataset, model=model)
-    eval_job._prepare()
+class SubgroupEvaluator:
+    def __init__(self, checkpoint_path, group_type):
+        # Load model and set the grouping type
+        self.checkpoint = load_checkpoint(checkpoint_path)
+        self.model = KgeModel.create_from(self.checkpoint)
+        self.group_type = group_type
+        self.test_triples = self.model.dataset.split("test")
     
-    # Override DataLoader with custom triples tensor
-    custom_loader = torch.utils.data.DataLoader(
-        triples_tensor, batch_size=model.config.get("eval.batch_size"), shuffle=False,
-        collate_fn=eval_job._collate,
-    )
-    eval_job.loader = custom_loader
-    eval_job.result = eval_job._run()
-    return eval_job.result
+    def group_triples(self):
+        """Groups triples in the test set by the specified type (subject, relation, or object)."""
 
-# Main function to evaluate subgroups based on group type
-def eval_subgroups(model, triples, group_type):
-    groups = group_triples(triples, group_type)
-    for key, triples in groups.items():
-        print(f"Evaluating {group_type} subgroup with key {key}")
-        results = evaluate(model, triples)
-        print(f"Results for {group_type} {key}: {results}")
+        groups = defaultdict(list)
+        for triple in self.test_triples:
+            if self.group_type == "subject":
+                key = triple[0].item()
+            elif self.group_type == "relation":
+                key = triple[1].item()
+            elif self.group_type == "object":
+                key = triple[2].item()
+            else:
+                raise ValueError("Invalid group_type. Choose from 'subject', 'relation', or 'object'.")
+            groups[key].append(triple)
+        return groups
 
-# Execute subgroup evaluation by desired grouping type
-eval_subgroups(model, test_triples, group_type="relation")
+    def evaluate(self, triples):
+        """Evaluates a batch of triples and returns results such as MRR and Hits@k."""
+
+        triples_tensor = torch.stack(triples).to(self.model.config.get("job.device"))
+
+        eval_job = EvaluationJob.create(self.model.config, dataset=self.model.dataset, model=self.model)
+        eval_job._prepare()
+        
+        custom_loader = torch.utils.data.DataLoader(
+            triples_tensor, batch_size=self.model.config.get("eval.batch_size"), shuffle=False,
+            collate_fn=eval_job._collate,
+        )
+        eval_job.loader = custom_loader
+        eval_job.result = eval_job._run()
+
+        return eval_job.result
+
+    def eval_subgroups(self):
+        """Evaluates and prints results for each subgroup based on the grouping type."""
+
+        groups = self.group_triples()
+        for key, triples in groups.items():
+            print(f"Evaluating {self.group_type} subgroup with key {key}")
+            self.evaluate(triples)
+
+evaluator = SubgroupEvaluator(
+    checkpoint_path='local/experiments/20241021-193745-wnrr-rescal/checkpoint_best.pt',
+    group_type="relation"  # Change to "subject" or "object" as needed
+)
+evaluator.eval_subgroups()


### PR DESCRIPTION
- **Train**: use all training triples to train RESCAL with the provided config file in the website.
- **Test**: first group triples based on relation/entity, then evaluate the subgroup separately and report the results.